### PR TITLE
feat: エージェント用CLAUDE.mdにGitコミット規約とPlaywright MCP使用制限を追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(touch:*)",
       "Bash(chmod:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git push:*)"
     ],
     "deny": []
   }

--- a/agents/boss/CLAUDE.md
+++ b/agents/boss/CLAUDE.md
@@ -270,6 +270,38 @@ cat > docs/best_practices/[topic].md
 - 品質スコア: XX%
 ```
 
+## Git コミット規約
+
+### コミット管理方針
+ボスとして、チーム全体のコミット品質を管理し、プロジェクトの履歴を清潔に保つ責任があります。
+
+### コミット頻度とタイミング
+- **レビュー完了時**: PRの承認とマージ時にコミット
+- **要件更新時**: 要件定義書の変更時
+- **タスク管理時**: タスク割り当てや優先順位変更時
+- **ドキュメント更新時**: プロジェクト関連文書の更新時
+
+### コミットメッセージ形式
+```bash
+# プロジェクト管理関連のプレフィックス
+chore: プロジェクト設定・管理
+docs: ドキュメント更新
+merge: ブランチマージ
+review: コードレビュー完了
+task: タスク管理関連
+
+# 例
+git add -A && git commit -m "chore: update project priorities for sprint 2"
+git add -A && git commit -m "docs: add API specification for auth module"
+git add -A && git commit -m "merge: integrate feature/user-auth into main"
+git add -A && git commit -m "review: approve implementation with minor suggestions"
+```
+
+### チームへの指導事項
+- 各エージェントに頻繁なコミットを推奨
+- コミットメッセージの一貫性を維持
+- 意味のある単位でのコミットを指導
+
 ## 緊急対応プロトコル
 
 ### インシデント対応
@@ -282,6 +314,41 @@ cat > docs/best_practices/[topic].md
 - ステークホルダーへの即時報告
 - 定期的な状況アップデート
 - 解決後の詳細レポート
+
+## Playwright MCP使用権限
+
+### ボスのみに許可される動作確認
+ボス（プロダクトオーナー）は、最終的な品質保証のため、**Playwright MCPの使用が許可**されています。
+
+1. **使用条件**
+   - mainブランチでの動作確認時のみ使用
+   - リリース前の最終確認
+   - 統合テストの実施
+   - ユーザー体験の検証
+
+2. **使用手順**
+   ```bash
+   # mainブランチに切り替え
+   git checkout main
+   git pull origin main
+   
+   # サーバー起動（1インスタンスのみ）
+   npm run dev
+   
+   # Playwright MCPを使用した動作確認
+   # ブラウザ操作による統合的なテスト実施
+   ```
+
+3. **他エージェントへの指導**
+   - エンジニア、デザイナー、マーケターはPlaywright MCP使用禁止
+   - 各エージェントには代替手段を使用するよう指導
+   - リソース競合を防ぐためのルール徹底
+
+4. **動作確認のベストプラクティス**
+   - 各機能の統合的な動作確認
+   - ユーザーフローの完全性検証
+   - パフォーマンステスト
+   - アクセシビリティチェック
 
 ## ツールとコマンド
 

--- a/agents/designer/CLAUDE.md
+++ b/agents/designer/CLAUDE.md
@@ -145,6 +145,32 @@ xl: 1280px  /* 大画面 */
 </div>
 ```
 
+## Git コミット規約
+
+### コミット頻度とタイミング
+- **こまめなコミット**: デザインの各段階で定期的にコミット
+- **タイミング**:
+  - ワイヤーフレーム完成時
+  - カラーパレット・タイポグラフィ決定時
+  - 各画面デザイン完成時
+  - コンポーネント作成時
+  - アセット追加時
+
+### コミットメッセージ形式
+```bash
+# デザイン関連のプレフィックス
+design: UIデザイン変更
+style: スタイル調整
+assets: 画像・アイコン追加
+docs: デザインドキュメント更新
+
+# 例
+git add -A && git commit -m "design: add login screen wireframe"
+git add -A && git commit -m "style: update color palette for better contrast"
+git add -A && git commit -m "assets: add optimized hero images"
+git add -A && git commit -m "design: create reusable button components"
+```
+
 ## 作業完了時のチェックリスト
 
 - [ ] 全画面のデザイン完成
@@ -153,6 +179,7 @@ xl: 1280px  /* 大画面 */
 - [ ] デザインシステムとの整合性
 - [ ] 実装用アセットの準備
 - [ ] summary.txtの作成
+- [ ] 全ての変更をコミット済み
 
 ## レポート作成
 
@@ -182,3 +209,30 @@ tar -czf reports/[TASK_ID]_design_assets.tar.gz assets/ mockups/
    - 修正要望を文書化
    - 代替案の準備
    - 実装難易度の考慮
+
+## 🚨 絶対禁止事項（重要）
+
+### Playwright MCP使用の絶対禁止
+デザイナーエージェントは以下の理由により、Playwright MCPの使用を禁止します：
+
+1. **デザイン作業の性質**
+   - デザイナーの責務は視覚的なデザインとプロトタイプ作成
+   - 動作確認はボスとエンジニアの責務
+   - ブラウザでの最終確認はボスがmainブランチで実施
+
+2. **リソース管理**
+   - サーバー起動は1インスタンスのみ許可
+   - 複数ブランチでの同時起動は競合を引き起こす
+   - デザイナーは静的なHTMLプロトタイプで十分
+
+3. **代替手段**
+   ```bash
+   # 許可されているプレビュー方法
+   open mockups/index.html  # 静的HTMLのローカルプレビュー
+   python -m http.server 8000  # 簡易サーバーでのプレビュー
+   ```
+
+4. **デザイン確認のフロー**
+   - デザイナー: 静的プロトタイプ作成
+   - エンジニア: 実装とテスト
+   - ボス: 最終的な動作確認（Playwright MCP使用）

--- a/agents/engineer/CLAUDE.md
+++ b/agents/engineer/CLAUDE.md
@@ -115,6 +115,29 @@ $WORKSPACE_DIR/scripts/protect-tests.sh unlock [TASK_ID]
 - 重要な機能には統合テストを追加
 - E2Eテストは主要なユーザーフローに対して実装
 
+### 5. Git コミット規約
+- **頻度**: 機能の小さな単位ごとにこまめにコミット
+- **タイミング**: 
+  - テストが通った時点で即座にコミット
+  - リファクタリング完了時
+  - 各フェーズの完了時
+- **コミットメッセージ形式**:
+  ```
+  type(scope): description
+  
+  - feat: 新機能
+  - fix: バグ修正
+  - test: テスト追加・修正
+  - refactor: リファクタリング
+  - docs: ドキュメント更新
+  ```
+- **例**:
+  ```bash
+  git add -A && git commit -m "feat(auth): implement user authentication logic"
+  git add -A && git commit -m "test(auth): add test cases for invalid credentials"
+  git add -A && git commit -m "refactor(auth): extract password verification to utility"
+  ```
+
 ## TDD実装例（T-WADAスタイル）
 
 ### テスト設計フェーズ（実装前）
@@ -285,6 +308,31 @@ cp $WORKSPACE_DIR/templates/engineer-template.md reports/[TASK_ID]_summary.txt
 3. **テストのスキップ（test.skip, describe.skip）**
 4. **テストのコメントアウト**
 5. **期待値の変更**
+
+### Playwright MCP使用の絶対禁止
+エンジニアエージェントは以下の理由により、Playwright MCPの使用を禁止します：
+
+1. **リソース競合の防止**
+   - サーバー/データベースの起動は1インスタンスのみ
+   - 複数のブランチで同時実行すると競合が発生
+   
+2. **動作確認のルール**
+   - 最終的な動作確認はボスがmainブランチで実施
+   - エンジニアは単体テスト・統合テストで品質保証
+   - E2Eテストはテストコードとして実装（実行はボスが担当）
+
+3. **代替手段**
+   ```bash
+   # 許可されているテスト方法
+   npm test              # 単体テスト
+   npm run test:integration  # 統合テスト
+   npm run test:e2e     # E2Eテスト（ヘッドレスモード）
+   ```
+
+4. **違反時の影響**
+   - ポート競合によるエラー
+   - データベース接続エラー
+   - 他エージェントの作業妨害
 
 ### 違反時のペナルティ
 ```bash

--- a/agents/marketer/CLAUDE.md
+++ b/agents/marketer/CLAUDE.md
@@ -168,6 +168,33 @@ conversion_metrics:
 | 2  | LP更新 | SNS | ブログ | SNS | 分析 |
 ```
 
+## Git コミット規約
+
+### コミット頻度とタイミング
+- **こまめなコミット**: コンテンツの各段階で定期的にコミット
+- **タイミング**:
+  - コンテンツ構成作成時
+  - ドラフト完成時
+  - SEO最適化完了時
+  - 画像・アセット追加時
+  - 最終校正完了時
+
+### コミットメッセージ形式
+```bash
+# マーケティング関連のプレフィックス
+content: コンテンツ作成・更新
+seo: SEO最適化
+copy: コピーライティング変更
+assets: マーケティング素材追加
+analytics: 分析・レポート関連
+
+# 例
+git add -A && git commit -m "content: create landing page hero section copy"
+git add -A && git commit -m "seo: optimize meta tags for product pages"
+git add -A && git commit -m "copy: refine CTA button text for higher conversion"
+git add -A && git commit -m "content: add FAQ section to improve user experience"
+```
+
 ## 作業完了時のチェックリスト
 
 - [ ] コンテンツの校正完了
@@ -176,6 +203,7 @@ conversion_metrics:
 - [ ] 法的チェック（必要に応じて）
 - [ ] 画像の著作権確認
 - [ ] summary.txtの作成
+- [ ] 全ての変更をコミット済み
 
 ## レポート作成
 
@@ -218,3 +246,37 @@ cp -r content/* reports/[TASK_ID]_content/
 - ネガティブフィードバックへの迅速な対応
 - 危機管理コミュニケーション計画
 - ステークホルダーへの連絡体制
+
+## 🚨 絶対禁止事項（重要）
+
+### Playwright MCP使用の絶対禁止
+マーケターエージェントは以下の理由により、Playwright MCPの使用を禁止します：
+
+1. **マーケティング作業の性質**
+   - マーケターの責務はコンテンツ作成とSEO最適化
+   - 技術的な動作確認は専門外
+   - 最終的なユーザー体験確認はボスが担当
+
+2. **リソース競合の回避**
+   - アプリケーションサーバーは1インスタンスのみ
+   - データベース接続の競合を防ぐ
+   - 同時実行による予期しないエラーを回避
+
+3. **作業フォーカス**
+   - コンテンツ品質に集中
+   - SEO技術要件の文書化に専念
+   - 実装詳細はエンジニアに委託
+
+4. **許可されている確認方法**
+   ```bash
+   # 静的コンテンツのプレビュー
+   open content/landing-page.html
+   
+   # Markdownプレビュー
+   grip content/blog-post.md  # GitHub風プレビュー
+   ```
+
+5. **コンテンツ確認のフロー**
+   - マーケター: コンテンツ作成とSEO最適化
+   - エンジニア: 技術的実装
+   - ボス: 最終的なユーザー体験確認（Playwright MCP使用）


### PR DESCRIPTION
- 各エージェントに頻繁なコミットを促すGit規約を追加
  - エンジニア: feat/fix/test/refactor形式
  - デザイナー: design/style/assets形式
  - マーケター: content/seo/copy形式
  - ボス: chore/docs/merge/review形式

- Playwright MCP使用制限を明確化
  - ボス以外のエージェントは使用禁止（リソース競合防止）
  - ボスのみmainブランチで最終動作確認時に使用許可
  - 各エージェントに代替手段を明記

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced detailed Git commit guidelines for boss, designer, engineer, and marketer roles, specifying commit frequency, message formats, and responsibilities.
  * Added explicit role-based restrictions and procedures for using Playwright MCP, reserving its use exclusively for the boss and prohibiting access for other roles.
  * Clarified workflows, responsibilities, and best practices for version control and testing across all roles.

* **Chores**
  * Updated configuration to allow the "git push" command for permitted Bash operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->