### PR TITLE
fix: remove unnecessary instruction-reminders from setup script

### DIFF
--- a/setup-as-subdirectory.sh
+++ b/setup-as-subdirectory.sh
@@ -72,11 +72,6 @@ if [ "$CLAUDE_MD_CREATED" = true ]; then
 - **Designer**: `@/ai-multi-agent/agents/designer/CLAUDE.md`
 - **Marketer**: `@/ai-multi-agent/agents/marketer/CLAUDE.md`
 
-# important-instruction-reminders
-Do what has been asked; nothing more, nothing less.
-NEVER create files unless they're absolutely necessary for achieving your goal.
-ALWAYS prefer editing an existing file to creating a new one.
-NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 EOF
     echo "✅ $PROJECT_ROOT/CLAUDE.md を作成しました"
 fi


### PR DESCRIPTION
## 概要
セットアップスクリプトで生成されるCLAUDE.mdから不要なinstruction-remindersセクションを削除します。

## 変更内容
- setup-as-subdirectory.shからimportant-instruction-remindersセクションを削除
- ユーザーが明示的に要求していない指示内容は含めないように修正

## 理由
ユーザーから指摘があったように、この指示内容は明示的に要求されておらず、
CLAUDE.mdの指示書に従って不要なドキュメント内容は含めるべきではありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * `CLAUDE.md` から「重要な指示のリマインダー」セクションを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->